### PR TITLE
Add dark mode toggle

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -213,6 +213,7 @@
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
+      <button id="darkModeToggle" class="dark-mode-toggle" aria-label="Toggle dark mode">🌙</button>
     </div>
   </header>
   
@@ -323,6 +324,17 @@
         });
       });
     });
+  </script>
+  <script>
+    (function() {
+      const toggleBtn = document.getElementById('darkModeToggle');
+      const prefersDark = localStorage.getItem('darkMode') === 'true';
+      if (prefersDark) document.body.classList.add('dark-mode');
+      toggleBtn.addEventListener('click', function () {
+        document.body.classList.toggle('dark-mode');
+        localStorage.setItem('darkMode', document.body.classList.contains('dark-mode'));
+      });
+    })();
   </script>
 </body>
 </html>

--- a/blog1.html
+++ b/blog1.html
@@ -249,6 +249,7 @@
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
+      <button id="darkModeToggle" class="dark-mode-toggle" aria-label="Toggle dark mode">🌙</button>
     </div>
   </header>
   
@@ -338,11 +339,22 @@
     
     // Reading progress bar
     window.addEventListener('scroll', function () {
-      const progressBar = document.getElementById('progressBar');
-      const totalHeight = document.body.scrollHeight - window.innerHeight;
-      const progress = (window.scrollY / totalHeight) * 100;
-      progressBar.style.width = progress + '%';
-    });
+    const progressBar = document.getElementById('progressBar');
+    const totalHeight = document.body.scrollHeight - window.innerHeight;
+    const progress = (window.scrollY / totalHeight) * 100;
+    progressBar.style.width = progress + '%';
+  });
+  </script>
+  <script>
+    (function() {
+      const toggleBtn = document.getElementById('darkModeToggle');
+      const prefersDark = localStorage.getItem('darkMode') === 'true';
+      if (prefersDark) document.body.classList.add('dark-mode');
+      toggleBtn.addEventListener('click', function () {
+        document.body.classList.toggle('dark-mode');
+        localStorage.setItem('darkMode', document.body.classList.contains('dark-mode'));
+      });
+    })();
   </script>
 </body>
 </html>

--- a/blog2.html
+++ b/blog2.html
@@ -21,6 +21,7 @@
           <li><a href="index.html#contact" class="nav-link">Contact</a></li>
         </ul>
       </nav>
+      <button id="darkModeToggle" class="dark-mode-toggle" aria-label="Toggle dark mode">🌙</button>
     </div>
   </header>
 
@@ -72,6 +73,17 @@
         header.classList.remove('scrolled');
       }
     });
+  </script>
+  <script>
+    (function() {
+      const toggleBtn = document.getElementById('darkModeToggle');
+      const prefersDark = localStorage.getItem('darkMode') === 'true';
+      if (prefersDark) document.body.classList.add('dark-mode');
+      toggleBtn.addEventListener('click', function () {
+        document.body.classList.toggle('dark-mode');
+        localStorage.setItem('darkMode', document.body.classList.contains('dark-mode'));
+      });
+    })();
   </script>
 </body>
 </html>

--- a/blog3.html
+++ b/blog3.html
@@ -21,6 +21,7 @@
           <li><a href="index.html#contact" class="nav-link">Contact</a></li>
         </ul>
       </nav>
+      <button id="darkModeToggle" class="dark-mode-toggle" aria-label="Toggle dark mode">🌙</button>
     </div>
   </header>
 
@@ -76,6 +77,17 @@
         header.classList.remove('scrolled');
       }
     });
+  </script>
+  <script>
+    (function() {
+      const toggleBtn = document.getElementById('darkModeToggle');
+      const prefersDark = localStorage.getItem('darkMode') === 'true';
+      if (prefersDark) document.body.classList.add('dark-mode');
+      toggleBtn.addEventListener('click', function () {
+        document.body.classList.toggle('dark-mode');
+        localStorage.setItem('darkMode', document.body.classList.contains('dark-mode'));
+      });
+    })();
   </script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -22,6 +22,7 @@
           <li><a href="contact.html" class="nav-link active">Contact</a></li>
         </ul>
       </nav>
+      <button id="darkModeToggle" class="dark-mode-toggle" aria-label="Toggle dark mode">🌙</button>
     </div>
   </header>
 
@@ -68,6 +69,17 @@
         header.classList.remove('scrolled');
       }
     });
+  </script>
+  <script>
+    (function() {
+      const toggleBtn = document.getElementById('darkModeToggle');
+      const prefersDark = localStorage.getItem('darkMode') === 'true';
+      if (prefersDark) document.body.classList.add('dark-mode');
+      toggleBtn.addEventListener('click', function () {
+        document.body.classList.toggle('dark-mode');
+        localStorage.setItem('darkMode', document.body.classList.contains('dark-mode'));
+      });
+    })();
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
+      <button id="darkModeToggle" class="dark-mode-toggle" aria-label="Toggle dark mode">🌙</button>
     </div>
   </header>
 
@@ -62,6 +63,17 @@
         header.classList.remove('scrolled');
       }
     });
+  </script>
+  <script>
+    (function() {
+      const toggleBtn = document.getElementById('darkModeToggle');
+      const prefersDark = localStorage.getItem('darkMode') === 'true';
+      if (prefersDark) document.body.classList.add('dark-mode');
+      toggleBtn.addEventListener('click', function () {
+        document.body.classList.toggle('dark-mode');
+        localStorage.setItem('darkMode', document.body.classList.contains('dark-mode'));
+      });
+    })();
   </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -10,6 +10,15 @@
   --transition-speed: 0.3s;
 }
 
+/* Dark mode overrides */
+body.dark-mode {
+  --primary-color: #F9F7F7;
+  --secondary-color: #A4C6E4;
+  --accent-color: #112D4E;
+  --bg-color: #1A1A1A;
+  --card-bg: #263B5E;
+}
+
 /* Global Styles */
 * {
 margin: 0;
@@ -68,10 +77,25 @@ gap: 20px;
 }
 
 .nav-link {
-text-decoration: none;
-color: var(--secondary-color);
-font-weight: 500;
-transition: color var(--transition-speed);
+  text-decoration: none;
+  color: var(--secondary-color);
+  font-weight: 500;
+  transition: color var(--transition-speed);
+}
+
+/* Dark mode toggle button */
+.dark-mode-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2rem;
+  margin-left: 10px;
+  color: var(--secondary-color);
+  transition: color var(--transition-speed);
+}
+
+.dark-mode-toggle:hover {
+  color: var(--primary-color);
 }
 
 .nav-link:hover,


### PR DESCRIPTION
## Summary
- add dark mode palette to main stylesheet
- style a button for toggling modes
- insert a dark mode toggle button in the header of every page
- persist dark mode preference across pages with JavaScript

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685d7043d5788322b7192a0c70277585